### PR TITLE
Restrict packagecompiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,3 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "DynamicallyLoadedEmbedding"
 uuid = "bb81f446-86f5-47d0-8ffc-7ac2adc264fd"
 authors = ["Gunnar Farnebäck <gunnar.farneback@contextvision.se>"]
-version = "0.1.1"
-
-[deps]
+version = "0.2.0"
 
 [compat]
+PackageCompiler = "~1.2, ~1.3, ~1.4, ~1.5, ~1.6"
 julia = "1"
-PackageCompiler = "1.2"
 
 [extras]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/c/julia_cfunctions.c
+++ b/c/julia_cfunctions.c
@@ -1,6 +1,11 @@
 #include "julia_embedding.h"
 #include "julia_cfunctions.h"
 
+double (*julia_sind)(double x);
+int (*mutual_fibonacci)(int n, int (*callback)(int n));
+void (*add_element_number_int)(int *x, int n);
+void (*add_element_number_float)(float *x, int n);
+
 int load_julia_cfunctions()
 {
     julia_sind = get_cfunction_pointer("julia_sind");

--- a/c/julia_cfunctions.h
+++ b/c/julia_cfunctions.h
@@ -4,12 +4,12 @@
 /* Note, these declarations are function pointers. They can still be
  * called like regular functions without dereferencing.
  */
-double (*julia_sind)(double x);
-int (*mutual_fibonacci)(int n, int (*callback)(int n));
-void (*add_element_number_int)(int *x, int n);
-void (*add_element_number_float)(float *x, int n);
+extern double (*julia_sind)(double x);
+extern int (*mutual_fibonacci)(int n, int (*callback)(int n));
+extern void (*add_element_number_int)(int *x, int n);
+extern void (*add_element_number_float)(float *x, int n);
 
 /* Loads the function pointers above. */
-int load_julia_cfunctions(void);
+extern int load_julia_cfunctions(void);
 
 #endif

--- a/c/julia_embedding.c
+++ b/c/julia_embedding.c
@@ -20,7 +20,7 @@
 #include <libgen.h>
 #endif
 
-/* Load a minimal subset of the functions from julia.h dynamically.
+/* Load a minimal subset of the functions from julia.h dynamically. */
 
 /* We could get the definitions of these structs from
  * `#include "julia.h"`, but we only need to declare them and

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,10 @@ if Sys.iswindows()
     # Place `julia` in PATH. It is assumed that this makes `libjulia`
     # also available from PATH.
     ENV["PATH"] = string(Sys.BINDIR, ";", ENV["PATH"])
+elseif Sys.isapple()
+    # Make `libjulia` available in LD_LIBRARY_PATH.
+    libdir = dirname(abspath(Libdl.dlpath("libjulia")))
+    ENV["DYLD_LIBRARY_PATH"] = string(libdir, ":", get(ENV, "DYLD_LIBRARY_PATH", ""))
 else
     # Make `libjulia` available in LD_LIBRARY_PATH.
     libdir = dirname(abspath(Libdl.dlpath("libjulia")))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,14 @@ end
     err = Pipe()
     # Use the default system image to test the custom system image
     # code paths.
-    p = run(pipeline(`$(binary_path) $(default_sysimg_path()) $(cfunctions_path)`,
+    #
+    # Update: Actually this is too simple and not sufficiently
+    # representative of a real use case. To improve it we still use
+    # the default system image but copy it to another location first.
+    custom_sysimg_path, io = mktemp()
+    write(io, read(default_sysimg_path()))
+    close(io)
+    p = run(pipeline(`$(binary_path) $(custom_sysimg_path) $(cfunctions_path)`,
                      stdin=devnull, stdout=out, stderr=err))
     close(out.in)
     close(err.in)


### PR DESCRIPTION
For running the tests, this package piggy-backs on PackageCompiler to obtain a C compiler. However, that's an internal detail of PackageCompiler and recent versions no longer work for this purpose, so restrict the compat.
